### PR TITLE
Fix: Configure and run servers to display Printful products

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host 0.0.0.0",
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",


### PR DESCRIPTION
This commit addresses an issue where Printful products were not being displayed on the page. The root cause was a combination of configuration and startup problems in the frontend and backend services.

The following fixes were implemented:
- Added a `.env` file to the server with the necessary `PRINTFUL_API_TOKEN` to enable successful authentication with the Printful API.
- Corrected the client-side development server startup script in `package.json` by adding the `--host 0.0.0.0` flag to resolve an IPv6-related network issue.
- Ensured both the backend and frontend servers can be started correctly to establish communication between them.

With these changes, the application is now properly configured to fetch products from the Printful API via the backend proxy and display them on the frontend.