### PR TITLE
Fix: Update Printful integration to use correct API fields

### DIFF
--- a/src/components/PrintfulProductGrid.tsx
+++ b/src/components/PrintfulProductGrid.tsx
@@ -46,14 +46,14 @@ const PrintfulProductGrid: React.FC = () => {
     const cartItem: CartItem = {
       productId: product.id,
       variantId: variant.id,
-      name: `${product.name} - ${variant.name}`,
+      name: `${product.title} - ${variant.name}`,
       price: variant.price,
       quantity: 1,
-      image: product.thumbnail_url,
+      image: product.image,
     };
 
     dispatch({ type: 'ADD_ITEM', payload: cartItem });
-    toast.success(`Added ${product.name} to cart`);
+    toast.success(`Added ${product.title} to cart`);
   };
 
   if (loading) {
@@ -130,8 +130,8 @@ const PrintfulProductGrid: React.FC = () => {
                 {/* Product Image */}
                 <div className="relative aspect-square overflow-hidden bg-gray-100">
                   <img
-                    src={product.thumbnail_url}
-                    alt={product.name}
+                    src={product.image}
+                    alt={product.title}
                     className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
                     loading="lazy"
                     onError={(e) => {
@@ -173,8 +173,9 @@ const PrintfulProductGrid: React.FC = () => {
                 {/* Product Info */}
                 <div className="p-4">
                   <h3 className="font-semibold text-lg mb-2 text-gray-900 group-hover:text-black transition-colors">
-                    {product.name}
+                    {product.title}
                   </h3>
+                  <p className="text-sm text-gray-500 mb-4 truncate">{product.description}</p>
 
                   {/* Price Range */}
                   {product.variants.length > 0 && (

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -14,8 +14,9 @@ export interface PrintfulResponse<T> {
 
 export interface PrintfulProduct {
   id: number;
-  name: string;
-  thumbnail_url: string;
+  title: string;
+  image: string;
+  description: string;
   variants: PrintfulVariant[];
 }
 


### PR DESCRIPTION
This commit resolves the issue of products not displaying by updating the frontend to use the correct field names from the Printful API response. The API service and product grid component have been aligned with the official Printful API documentation.

The following changes were made:
- The `PrintfulProduct` interface in `src/services/api.ts` was updated to use `title`, `image`, and `description` instead of the previous incorrect field names.
- The `PrintfulProductGrid.tsx` component was modified to render product data using the correct fields: `product.title`, `product.image`, and `product.description`. The price is correctly sourced from the product's variant data.
- The `addToCart` function was also updated to use the correct product fields.

This ensures that the data fetched from the Printful API is correctly mapped to the UI components, allowing the products to be displayed as intended.