### PR TITLE
Fix: Align collection dropdown with brand logo

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -222,7 +222,7 @@ const Navigation = ({ currentSection, forceSolidBg = false }: NavigationProps) =
                   <motion.div
                     ref={dropdownRef}
                     className="absolute top-full"
-                    style={{ left: logoWidth }}
+                    style={{ left: `-${collectionLinkRef.current?.offsetLeft ? collectionLinkRef.current.offsetLeft - logoWidth : 0}px` }}
                     initial={{ opacity: 0, y: -10, scale: 0.95 }}
                     animate={{ opacity: 1, y: 0, scale: 1 }}
                     exit={{ opacity: 0, y: -10, scale: 0.95 }}


### PR DESCRIPTION
This commit adjusts the positioning of the collection dropdown menu in the navigation bar. Previously, the dropdown was aligned with the 'Collection' menu item. It is now aligned with the end of the 'SCARMO' brand logo.

The `left` position of the dropdown is now dynamically calculated based on the offset of the 'Collection' link and the width of the logo, ensuring correct alignment.