### PR TITLE
Refactor: Center 'Long-Sleeves' in collection dropdown

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -49,6 +49,11 @@ const Navigation = ({ currentSection, forceSolidBg = false }: NavigationProps) =
     { id: 'underwear', label: t('nav.underwear') },
   ];
 
+  const centerIndex = collectionItems.findIndex(item => item.id === 'longSleeves');
+  const leftItems = collectionItems.slice(0, centerIndex);
+  const centerItem = collectionItems[centerIndex];
+  const rightItems = collectionItems.slice(centerIndex + 1);
+
   // All hooks must be called before any conditional returns
   useEffect(() => {
     if (forceSolidBg) return;
@@ -229,10 +234,11 @@ const Navigation = ({ currentSection, forceSolidBg = false }: NavigationProps) =
                     onMouseEnter={() => setIsCollectionOpen(true)}
                     onMouseLeave={() => setIsCollectionOpen(false)}
                   >
-                    <ul className="list-none bg-white rounded-lg shadow-lg p-2 z-50 flex justify-center space-x-4 w-[max-content] px-6">
-                      {collectionItems.map((item) => (
-                        <li key={item.id} className="flex-shrink-0">
+                    <div className="list-none bg-white rounded-lg shadow-lg p-2 z-50 flex justify-center items-center space-x-4 w-[max-content] px-6">
+                      <div className="flex items-center space-x-4">
+                        {leftItems.map((item) => (
                           <button
+                            key={item.id}
                             onClick={() => {
                               scrollToSection(item.id);
                               setIsCollectionOpen(false);
@@ -245,9 +251,42 @@ const Navigation = ({ currentSection, forceSolidBg = false }: NavigationProps) =
                           >
                             {item.label}
                           </button>
-                        </li>
-                      ))}
-                    </ul>
+                        ))}
+                      </div>
+                      <div className="flex-shrink-0">
+                        <button
+                          onClick={() => {
+                            scrollToSection(centerItem.id);
+                            setIsCollectionOpen(false);
+                          }}
+                          className={`w-full text-left px-4 py-2 rounded-md transition-colors duration-200 focus-luxury hover:bg-gray-100 ${
+                            currentSection === centerItem.id
+                              ? 'bg-accent text-accent-foreground'
+                              : 'text-foreground'
+                          }`}
+                        >
+                          {centerItem.label}
+                        </button>
+                      </div>
+                      <div className="flex items-center space-x-4">
+                        {rightItems.map((item) => (
+                          <button
+                            key={item.id}
+                            onClick={() => {
+                              scrollToSection(item.id);
+                              setIsCollectionOpen(false);
+                            }}
+                            className={`w-full text-left px-4 py-2 rounded-md transition-colors duration-200 focus-luxury hover:bg-gray-100 ${
+                              currentSection === item.id
+                                ? 'bg-accent text-accent-foreground'
+                                : 'text-foreground'
+                            }`}
+                          >
+                            {item.label}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
                   </motion.div>
                 )}
               </AnimatePresence>


### PR DESCRIPTION
This commit refactors the collection dropdown menu in the navigation bar to center the 'Long-Sleeves' item directly under the 'Collection' link. This provides a better visual anchor and a more symmetrical layout for the dropdown items.

The following changes were made:
- The `collectionItems` array is now programmatically split into three parts: items to the left of 'Long-Sleeves', the 'Long-Sleeves' item itself, and items to the right.
- The dropdown's rendering logic in `Navigation.tsx` was updated to use three separate flex containers for these three parts.
- This new structure allows for precise centering of the 'Long-Sleeves' item while maintaining the existing styles and flexbox layout for the other items.