### PR TITLE
Fix: Reduce font size of collection dropdown items

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -243,7 +243,7 @@ const Navigation = ({ currentSection, forceSolidBg = false }: NavigationProps) =
                               scrollToSection(item.id);
                               setIsCollectionOpen(false);
                             }}
-                            className={`w-full text-left px-4 py-2 rounded-md transition-colors duration-200 focus-luxury hover:bg-gray-100 ${
+                            className={`w-full text-left px-4 py-2 text-sm rounded-md transition-colors duration-200 focus-luxury hover:bg-gray-100 ${
                               currentSection === item.id
                                 ? 'bg-accent text-accent-foreground'
                                 : 'text-foreground'
@@ -259,7 +259,7 @@ const Navigation = ({ currentSection, forceSolidBg = false }: NavigationProps) =
                             scrollToSection(centerItem.id);
                             setIsCollectionOpen(false);
                           }}
-                          className={`w-full text-left px-4 py-2 rounded-md transition-colors duration-200 focus-luxury hover:bg-gray-100 ${
+                          className={`w-full text-left px-4 py-2 text-sm rounded-md transition-colors duration-200 focus-luxury hover:bg-gray-100 ${
                             currentSection === centerItem.id
                               ? 'bg-accent text-accent-foreground'
                               : 'text-foreground'
@@ -276,7 +276,7 @@ const Navigation = ({ currentSection, forceSolidBg = false }: NavigationProps) =
                               scrollToSection(item.id);
                               setIsCollectionOpen(false);
                             }}
-                            className={`w-full text-left px-4 py-2 rounded-md transition-colors duration-200 focus-luxury hover:bg-gray-100 ${
+                            className={`w-full text-left px-4 py-2 text-sm rounded-md transition-colors duration-200 focus-luxury hover:bg-gray-100 ${
                               currentSection === item.id
                                 ? 'bg-accent text-accent-foreground'
                                 : 'text-foreground'


### PR DESCRIPTION
This commit reduces the font size of the items in the collection dropdown menu to make them more compact and visually proportionate.

I've added the `text-sm` Tailwind CSS class to the buttons for the dropdown items in `src/components/Navigation.tsx`. This makes the text smaller while preserving the existing layout, padding, and hover effects.