### PR TITLE
I've made a change to the products page. Previously, the application …

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -81,7 +81,14 @@ class ApiService {
         },
       };
     } else {
-      throw new Error('Supabase or Printful API token configuration is missing');
+      return {
+        code: 400,
+        result: null as T,
+        error: {
+          reason: 'Configuration Error',
+          message: 'Supabase or Printful API token configuration is missing',
+        },
+      };
     }
 
     try {


### PR DESCRIPTION
…would crash if no API keys for Supabase or Printful were provided. Now, if there's a configuration error due to missing API keys, the `Products` component will load a local set of mock products instead. This ensures you can always run the application for development and testing, even without API credentials.